### PR TITLE
Pin oura to tagged version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23710,7 +23710,7 @@
       },
       "original": {
         "owner": "szg251",
-        "ref": "szg251/add-ref-script",
+        "ref": "v1.9.1",
         "repo": "oura",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
 
     oura = {
       flake = false;
-      url = "github:szg251/oura?ref=szg251/add-ref-script";
+      url = "github:szg251/oura?ref=v1.9.1";
     };
 
     cardano-nix.url = "github:mlabs-haskell/cardano.nix";


### PR DESCRIPTION
I've updated the Oura version in my branch here https://github.com/txpipe/oura/pull/821, so I pinned the old version to a tag to avoid breaking stuff in older versions
btw, kudos to txpipe for ignoring my issue and PR for months